### PR TITLE
Add instructions to run the script manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ a US government agency.
 
 To change the time of day that the email is sent, edit the cron job definition in the Dockerfile.
 
+If you want to run this manually, run ``python main.py`` in the container console.
+
 ## Environment Variables
 - WEATHER_API_KEY: Your NWS weather API key. Currently, this is your email address as a string. (optional)
 - LATITUDE: The latitude you wish to use for the weather. (optional)


### PR DESCRIPTION
Updated README.md with a command to manually run the script using `python main.py` in the container console. This helps users execute the script outside the scheduled cron job.